### PR TITLE
Changing actions from methods to fields

### DIFF
--- a/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
+++ b/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
@@ -15,25 +15,23 @@ public class ActionInfo
         CONTINUOUS
     }
 
-    public delegate void DiscreteAction(int actionValue);
-    public delegate void ContinuousAction(float actionValue);
-
-    public Delegate mActionCallback;
+    public int mActionDiscrete = 0;
+    public float mActionContinuous = 0f;
     public int mActionCount = 1;
     public TYPE mType;
 
-    public ActionInfo(DiscreteAction callback, int actionCount)
+    public ActionInfo(int actionDiscrete, int actionCount)
     {
         mType = TYPE.DISCRETE;
         mActionCount = actionCount;
-        mActionCallback = callback;
+        mActionDiscrete = actionDiscrete;
     }
 
-    public ActionInfo(ContinuousAction callback)
+    public ActionInfo(float actionContinuous)
     {
         mType = TYPE.CONTINUOUS;
         mActionCount = 1;
-        mActionCallback = callback;
+        mActionContinuous = actionContinuous;
     }
 
     public void DoAction(int actionValueDiscrete = 0, float actionValueContinuous = 0f)
@@ -41,10 +39,10 @@ public class ActionInfo
         switch (mType)
         {
             case TYPE.DISCRETE:
-                ((DiscreteAction)mActionCallback)?.Invoke(actionValueDiscrete);
+                mActionDiscrete = actionValueDiscrete;
                 break;
             case TYPE.CONTINUOUS:
-                ((ContinuousAction)mActionCallback)?.Invoke(actionValueContinuous);
+                mActionContinuous = actionValueContinuous;
                 break;
             default:
                 Debug.LogError("Invalid action type.");
@@ -186,7 +184,7 @@ public class EnvironmentAgent : EnvironmentComponent
         {
             if (actions.DiscreteActions.Length > i)
             {
-                mDiscreteActions[i].DoAction(actions.DiscreteActions[i], 0f);
+                mDiscreteActions[i].DoAction(actions.DiscreteActions[i]);
             }
         }
 

--- a/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
+++ b/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
@@ -35,6 +35,23 @@ public class ActionInfo
         mActionCount = 1;
         mActionCallback = callback;
     }
+
+    public void DoAction(int actionValueDiscrete = 0, float actionValueContinuous = 0f)
+    {
+        switch (mType)
+        {
+            case TYPE.DISCRETE:
+                ((DiscreteAction)mActionCallback)?.Invoke(actionValueDiscrete);
+                break;
+            case TYPE.CONTINUOUS:
+                ((ContinuousAction)mActionCallback)?.Invoke(actionValueContinuous);
+                break;
+            default:
+                Debug.LogError("Invalid action type.");
+                break;
+        }
+    }
+
 }
 
 [RequireComponent(typeof(U3Agent))]
@@ -131,7 +148,7 @@ public class EnvironmentAgent : EnvironmentComponent
     //[Callback(typeof(HealthBar), CallbackScope.SELF)]
     virtual protected void OnDied()
     {
-        DoEndEpisode();        
+        DoEndEpisode();
     }
 
     public void RequestDecision()
@@ -161,7 +178,7 @@ public class EnvironmentAgent : EnvironmentComponent
         {
             if (actions.ContinuousActions.Length > i)
             {
-                ((ActionInfo.ContinuousAction)mContinuousActions[i].mActionCallback)(actions.ContinuousActions[i]);
+                mContinuousActions[i].DoAction(0, actions.ContinuousActions[i]);
             }
         }
 
@@ -169,7 +186,7 @@ public class EnvironmentAgent : EnvironmentComponent
         {
             if (actions.DiscreteActions.Length > i)
             {
-                ((ActionInfo.DiscreteAction)mDiscreteActions[i].mActionCallback)(actions.DiscreteActions[i]);
+                mDiscreteActions[i].DoAction(actions.DiscreteActions[i], 0f);
             }
         }
 

--- a/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
+++ b/unity/Assets/Source/EnvironmentEngine/EnvironmentAgent.cs
@@ -59,8 +59,8 @@ public class EnvironmentAgent : EnvironmentComponent
     U3Agent mAgentScript;
     BehaviorParameters mBehaviorParameters;
 
-    List<ActionInfo> mDiscreteActions = new List<ActionInfo>();
-    List<ActionInfo> mContinuousActions = new List<ActionInfo>();
+    public List<ActionInfo> mDiscreteActions = new List<ActionInfo>();
+    public List<ActionInfo> mContinuousActions = new List<ActionInfo>();
 
     protected override void Initialize()
     {
@@ -172,19 +172,20 @@ public class EnvironmentAgent : EnvironmentComponent
 
     virtual public void OnActionReceived(ActionBuffers actions)
     {
-        for (int i = 0; i < mContinuousActions.Count; i++)
-        {
-            if (actions.ContinuousActions.Length > i)
-            {
-                mContinuousActions[i].DoAction(0, actions.ContinuousActions[i]);
-            }
-        }
-
         for (int i = 0; i < mDiscreteActions.Count; i++)
         {
             if (actions.DiscreteActions.Length > i)
             {
                 mDiscreteActions[i].DoAction(actions.DiscreteActions[i]);
+            }
+        }
+
+        for (int i = 0; i < mContinuousActions.Count; i++)
+        {
+            if (actions.ContinuousActions.Length > i)
+            {
+                mContinuousActions[i].DoAction(0, actions.ContinuousActions[i]);
+
             }
         }
 

--- a/unity/Assets/Source/EnvironmentEngine/EnvironmentComponent.cs
+++ b/unity/Assets/Source/EnvironmentEngine/EnvironmentComponent.cs
@@ -188,23 +188,20 @@ public class EnvironmentComponent : MonoBehaviour
                 Action actionAttribute = fieldInfo.GetCustomAttribute<Action>();
                 if (actionAttribute != null)
                 {
-                    Delegate callbackDelegate = (Delegate)fieldInfo.GetValue(this);
+                    object fieldValue = fieldInfo.GetValue(this);
 
-                    if (callbackDelegate is ActionInfo.DiscreteAction)
+                    if (fieldValue is int)
                     {
-                        ActionInfo.DiscreteAction discreteCallback = (ActionInfo.DiscreteAction)callbackDelegate;
-                        actionsList.Add(new ActionInfo(discreteCallback, actionAttribute.actionCount));
+                        actionsList.Add(new ActionInfo((int)fieldValue, actionAttribute.actionCount));
                     }
-                    else if (callbackDelegate is ActionInfo.ContinuousAction)
+                    else if (fieldValue is float)
                     {
-                        ActionInfo.ContinuousAction continuousCallback = (ActionInfo.ContinuousAction)callbackDelegate;
-                        actionsList.Add(new ActionInfo(continuousCallback));
+                        actionsList.Add(new ActionInfo((float)fieldValue));
                     }
                     else
                     {
-                        Debug.Log("Cannot add Action" + name + "(" + fieldInfo.Name + "). Field must be of type ActionInfo.DiscreteAction or ActionInfo.ContinuousAction.");
+                        Debug.Log("Cannot add Action" + name + "(" + fieldInfo.Name + "). Field must be of type int or float.");
                     }
-
                 }
             }
 

--- a/unity/Assets/Source/EnvironmentEngine/EnvironmentComponent.cs
+++ b/unity/Assets/Source/EnvironmentEngine/EnvironmentComponent.cs
@@ -23,7 +23,7 @@ public class Callback : Attribute
     }
 }
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
 public class Action : Attribute
 {
     public int actionCount = 1;
@@ -55,7 +55,7 @@ public delegate void EnvironmentCallback();
 public delegate void EnvironmentCallback<T>(T value = default(T));
 
 //base class for environment objects
-public class EnvironmentComponent : MonoBehaviour 
+public class EnvironmentComponent : MonoBehaviour
 {
     // Public members
 
@@ -95,7 +95,7 @@ public class EnvironmentComponent : MonoBehaviour
         }
     }
 
-    virtual protected void Initialize() 
+    virtual protected void Initialize()
     {
         CheckAll();
 
@@ -181,39 +181,30 @@ public class EnvironmentComponent : MonoBehaviour
         Type currentType = GetType();
         do
         {
-            MethodInfo[] methodInfos = currentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            FieldInfo[] fieldInfos = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-            foreach (MethodInfo methodInfo in methodInfos)
+            foreach (FieldInfo fieldInfo in fieldInfos)
             {
-                Action actionInfo = methodInfo.GetCustomAttribute<Action>();
-                if (actionInfo != null)
+                Action actionAttribute = fieldInfo.GetCustomAttribute<Action>();
+                if (actionAttribute != null)
                 {
-                    Delegate newCallback = null;
+                    Delegate callbackDelegate = (Delegate)fieldInfo.GetValue(this);
 
-                    ParameterInfo[] paramInfos = methodInfo.GetParameters();
-
-                    if (paramInfos.Length != 1)
+                    if (callbackDelegate is ActionInfo.DiscreteAction)
                     {
-                        Debug.Log("Cannot add Action" + name + "(" + methodInfo.Name + "). Function must have a single int or float parameter.");
-
-                        return;
+                        ActionInfo.DiscreteAction discreteCallback = (ActionInfo.DiscreteAction)callbackDelegate;
+                        actionsList.Add(new ActionInfo(discreteCallback, actionAttribute.actionCount));
                     }
-
-                    ActionInfo actionObject = null;
-                    if (paramInfos[0].ParameterType == typeof(int))
+                    else if (callbackDelegate is ActionInfo.ContinuousAction)
                     {
-                        newCallback = Delegate.CreateDelegate(typeof(ActionInfo.DiscreteAction), this, methodInfo);
-
-                        actionObject = new ActionInfo((ActionInfo.DiscreteAction)newCallback, actionInfo.actionCount);
+                        ActionInfo.ContinuousAction continuousCallback = (ActionInfo.ContinuousAction)callbackDelegate;
+                        actionsList.Add(new ActionInfo(continuousCallback));
                     }
                     else
                     {
-                        newCallback = Delegate.CreateDelegate(typeof(ActionInfo.ContinuousAction), this, methodInfo);
-
-                        actionObject = new ActionInfo((ActionInfo.ContinuousAction)newCallback);
+                        Debug.Log("Cannot add Action" + name + "(" + fieldInfo.Name + "). Field must be of type ActionInfo.DiscreteAction or ActionInfo.ContinuousAction.");
                     }
 
-                    actionsList.Add(actionObject);
                 }
             }
 
@@ -375,7 +366,7 @@ public class EnvironmentComponent : MonoBehaviour
                 }
 
                 currentType = currentType.BaseType;
-            } 
+            }
             while (currentType == typeof(EnvironmentComponent) || currentType.IsSubclassOf(typeof(EnvironmentComponent)));
         }
     }
@@ -443,13 +434,13 @@ public class EnvironmentComponent : MonoBehaviour
         OnPreGetState();
 
         JSONObject fullComponent = new JSONObject();
-        
+
         int i = 0;
         foreach (PropertyInfo propertyInfo in mSaveProperties)
         {
             if (name == "Player")
             {
-                int  test = 1;
+                int test = 1;
             }
 
             string defaultValue = null;

--- a/unity/Assets/Source/Other/Player3D.cs
+++ b/unity/Assets/Source/Other/Player3D.cs
@@ -54,7 +54,13 @@ public class Player3D : EnvironmentAgent
 
     void Update()
     {
+        ReadAction();
         DoMovement();
+    }
+
+    void ReadAction()
+    {
+        doMovement = mDiscreteActions[0].mActionDiscrete;
     }
 
     void DoMovement()

--- a/unity/Assets/Source/Other/Player3D.cs
+++ b/unity/Assets/Source/Other/Player3D.cs
@@ -15,12 +15,17 @@ public class Player3D : EnvironmentAgent
     Movement mMovement;
     HealthBar mHealthBar;
 
+    [Action((int)GridEnvironment.Actions.NOOP)]
+    public ActionInfo.DiscreteAction doMovement;
+
     override protected void Initialize()
     {
         mMovement = GetComponent<Movement>();
         mHealthBar = GetComponent<HealthBar>();
 
         base.Initialize();
+
+        doMovement = new ActionInfo.DiscreteAction(DoMovement);
     }
 
     public override void OnRunStarted()
@@ -48,7 +53,6 @@ public class Player3D : EnvironmentAgent
         mMovement.Velocity = Vector2.zero;
     }
 
-    [Action((int)GridEnvironment.Actions.NOOP)]
     void DoMovement(int actionValue)
     {
         float speed = tilesPerSecondSpeed;

--- a/unity/Assets/Source/Other/Player3D.cs
+++ b/unity/Assets/Source/Other/Player3D.cs
@@ -16,7 +16,7 @@ public class Player3D : EnvironmentAgent
     HealthBar mHealthBar;
 
     [Action((int)GridEnvironment.Actions.NOOP)]
-    public ActionInfo.DiscreteAction doMovement;
+    public int doMovement;
 
     override protected void Initialize()
     {
@@ -25,7 +25,6 @@ public class Player3D : EnvironmentAgent
 
         base.Initialize();
 
-        doMovement = new ActionInfo.DiscreteAction(DoMovement);
     }
 
     public override void OnRunStarted()
@@ -53,11 +52,16 @@ public class Player3D : EnvironmentAgent
         mMovement.Velocity = Vector2.zero;
     }
 
-    void DoMovement(int actionValue)
+    void Update()
+    {
+        DoMovement();
+    }
+
+    void DoMovement()
     {
         float speed = tilesPerSecondSpeed;
 
-        switch ((GridEnvironment.Actions)actionValue)
+        switch ((GridEnvironment.Actions)doMovement)
         {
             case GridEnvironment.Actions.NOOP:
                 mMovement.Velocity = Vector2.zero * speed;

--- a/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
+++ b/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
@@ -18,6 +18,10 @@ public class GridPlayer : EnvironmentAgent
     Movement mMovement;
     HealthBar mHealthBar;
 
+    [Action((int)GridEnvironment.Actions.NOOP)]
+    public ActionInfo.DiscreteAction doMovement;
+
+
     public float MaxSpeed
     {
         get { return tilesPerSecondSpeed; }
@@ -81,7 +85,6 @@ public class GridPlayer : EnvironmentAgent
         mMovement.Velocity = Vector2.zero;
     }
 
-    [Action((int)GridEnvironment.Actions.NOOP)]
     void DoMovement(int actionValue)
     {
         float speed = tilesPerSecondSpeed;

--- a/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
+++ b/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
@@ -87,9 +87,14 @@ public class GridPlayer : EnvironmentAgent
 
     void Update()
     {
+        ReadAction();
         DoMovement();
     }
 
+    void ReadAction()
+    {
+        doMovement = mDiscreteActions[0].mActionDiscrete;
+    }
 
     void DoMovement()
     {

--- a/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
+++ b/unity/Assets/Source/Scripts/GridWorld/GridPlayer.cs
@@ -19,7 +19,7 @@ public class GridPlayer : EnvironmentAgent
     HealthBar mHealthBar;
 
     [Action((int)GridEnvironment.Actions.NOOP)]
-    public ActionInfo.DiscreteAction doMovement;
+    public int doMovement;
 
 
     public float MaxSpeed
@@ -85,7 +85,13 @@ public class GridPlayer : EnvironmentAgent
         mMovement.Velocity = Vector2.zero;
     }
 
-    void DoMovement(int actionValue)
+    void Update()
+    {
+        DoMovement();
+    }
+
+
+    void DoMovement()
     {
         float speed = tilesPerSecondSpeed;
         if (mGridEngine)
@@ -93,7 +99,7 @@ public class GridPlayer : EnvironmentAgent
             speed = tilesPerSecondSpeed * mGridEngine.gridSize / mGridEngine.GetTurnTime();
         }
 
-        switch ((GridEnvironment.Actions)actionValue)
+        switch ((GridEnvironment.Actions)doMovement)
         {
             case GridEnvironment.Actions.NOOP:
                 mMovement.Velocity = Vector2.zero * speed;


### PR DESCRIPTION
Changes the handling of actions so that Environment components will have an action field instead of an action method, which is meant to make debugging easier.

Verified that the keygame environment still works with these modifications.