### PR TITLE
Add Prod Rule For Collision

### DIFF
--- a/unity/Assets/Source/EnvironmentEngine/ProductionRuleCondition.cs
+++ b/unity/Assets/Source/EnvironmentEngine/ProductionRuleCondition.cs
@@ -80,8 +80,10 @@ public class ProductionRuleCondition
 
             case CONDITION.DROP:
             case CONDITION.PICKUP:
+            case CONDITION.CONTACT:
             case CONDITION.THROW:
                 return condition == callbackCondition;
+
             // case CONDITION.USE:
             //     return CheckUse(subject, obj);
 

--- a/unity/Assets/Source/EnvironmentEngine/ProductionRuleManager.cs
+++ b/unity/Assets/Source/EnvironmentEngine/ProductionRuleManager.cs
@@ -184,7 +184,7 @@ public class ProductionRuleManager : EnvironmentComponent
         return NEAR_DISTANCE;
     }
 
-    private void CheckCallback(CONDITION condition, ProductionRuleObject sub, ProductionRuleObject obj, EnvironmentEngine env)
+    public void CheckCallback(CONDITION condition, ProductionRuleObject sub, ProductionRuleObject obj, EnvironmentEngine env)
     {
         foreach (ProductionRule rule in productionRules)
         {

--- a/unity/Assets/Source/EnvironmentEngine/ProductionRuleObject.cs
+++ b/unity/Assets/Source/EnvironmentEngine/ProductionRuleObject.cs
@@ -47,6 +47,15 @@ public class ProductionRuleObject : EnvironmentComponent
 
     }
 
+    public override void OnCollision(EnvironmentObject otherObject)
+    {
+        
+        ProductionRuleObject productionRuleObject = otherObject.GetComponentInParent<ProductionRuleObject>();
+        GetProductionRuleManager().CheckCallback(CONDITION.CONTACT, this, productionRuleObject, GetEngine());
+        base.OnCollision(otherObject);
+        Debug.Log("Object Collided");
+    }
+
     // public override void OnCreated()
     // {
     //     GetProductionRuleManager().AddProdRuleObject(this);


### PR DESCRIPTION
This commit creates production rules for collision. 

Manually tested in Unity Environment for intended usage.